### PR TITLE
the variable should be prompts instead of dataset in the doc

### DIFF
--- a/docs/_source/guides/llms/conceptual_guides/sft.md
+++ b/docs/_source/guides/llms/conceptual_guides/sft.md
@@ -115,7 +115,7 @@ prompts = load_dataset('your_prompts_dataset', split=["train"])
 
 records = [
 	rg.FeedbackRecord(fields={"prompt": record["prompt"]})
-	for record in dataset
+	for record in prompts
 ]
 
 dataset.add_records(records)


### PR DESCRIPTION


<!-- Thanks for your contribution! As part of our Community Growers initiative 🌱, we're donating Justdiggit bunds in your name to reforest sub-Saharan Africa. To claim your Community Growers certificate, please contact David Berenstein in our Slack community or fill in this form https://tally.so/r/n9XrxK once your PR has been merged. -->

# Description

In the list comprehension used to generate the records, the variable should be prompts instead of dataset.

**Type of change**

(Remember to title the PR according to the type of change)

- [x] Documentation update

**How Has This Been Tested**

(Please describe the tests that you ran to verify your changes.)

- [ ] `sphinx-autobuild` (read [Developer Documentation](https://docs.argilla.io/en/latest/community/developer_docs.html#building-the-documentation) for more details)

**Checklist**

- [ ] I added relevant documentation
- [ ] I followed the style guidelines of this project
- [ ] I did a self-review of my code
- [x] I made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I filled out [the contributor form](https://tally.so/r/n9XrxK) (see text above)
- [ ] I have added relevant notes to the `CHANGELOG.md` file (See https://keepachangelog.com/)
